### PR TITLE
Fixing Card Binder not increasing hand size when copied

### DIFF
--- a/jokers/card_binder.lua
+++ b/jokers/card_binder.lua
@@ -25,7 +25,7 @@ SMODS.Joker {
     end,
 
     add_to_deck = function(self, card, from_debuff)
-      if not G.GAME.blind.in_blind and card.ability.extra.active==false then
+      if not G.GAME.blind.in_blind then
         card.ability.extra.active=true
         G.hand:change_size(card.ability.extra.bonus_hs)
         card:juice_up()


### PR DESCRIPTION
Changes:
- Fixes issues where copying Card Binder did not increase the card count.

This was caused by the `active` attribute being duplicated as well, so no card increase was given, causing the actual hand size to decrease by 4 during Blinds.